### PR TITLE
Autodetect returns the deepest level if all labels are shared by several levels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: This package recodes numeric NOGA values to its value labels and vi
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends: 
     R (>= 2.10)
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,3 +25,6 @@ LazyData: true
 RoxygenNote: 7.3.1
 Depends: 
     R (>= 2.10)
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/automaticleveldetection.R
+++ b/R/automaticleveldetection.R
@@ -9,12 +9,9 @@ automaticleveldetection <- function(var, language) {
       noga.level <- "section"
     } else {
       label.var <- paste0("name_", language)
-      to.filter <- noga::lookup[[eval(label.var)]]
-      # Looking for the pattern from the end of string avoid taking narrower/deeper labels into account
+      # Looking for the exact match in the table avoids partial matches
       # eg. Enseignement would otherwise return Enseignement primaire, Enseignement secondaire and so on
-      matched.successfully <- sapply(paste0(unique(var), "$"), function(x) grepl(x, to.filter))
-      matched.succesfully.index <- which(rowSums(matched.successfully) > 0)
-      lookup.filtered <- noga::lookup[matched.succesfully.index, ]
+      lookup.filtered <- noga::lookup[noga::lookup[[label.var]] %in% unique(var), ]
 
       if (nrow(lookup.filtered) == 0) {
         # No match in the lookup table
@@ -33,6 +30,7 @@ automaticleveldetection <- function(var, language) {
 
       # If ties, take the deepest level
       if (length(noga.level) > 1) {
+        message(paste("Several plausible levels:", paste(noga.level, collapse=",")))
         if ("type" %in% noga.level) {
           noga.level <- "type"
         } else if ("class" %in% noga.level) {

--- a/R/automaticleveldetection.R
+++ b/R/automaticleveldetection.R
@@ -2,34 +2,61 @@
 #' @name automaticleveldetection
 #' @noRd
 
-automaticleveldetection <- function(var,language){
-  if(any(grepl("[A-Za-z]", var) )==TRUE){
+automaticleveldetection <- function(var, language) {
+  if (any(grepl("[A-Za-z]", var))) {
+    # Section are either a code of one letter or all uppercase labels
+    if (max(nchar(var)) == 1 | ! any(grepl("[a-z]", var))) {
+      noga.level <- "section"
+    } else {
+      label.var <- paste0("name_", language)
+      to.filter <- noga::lookup[[eval(label.var)]]
+      # Looking for the pattern from the end of string avoid taking narrower/deeper labels into account
+      # eg. Enseignement would otherwise return Enseignement primaire, Enseignement secondaire and so on
+      matched.successfully <- sapply(paste0(unique(var), "$"), function(x) grepl(x, to.filter))
+      matched.succesfully.index <- which(rowSums(matched.successfully) > 0)
+      lookup.filtered <- noga::lookup[matched.succesfully.index, ]
 
-
-      if(max(nchar(var))==1){
-        noga.level <- "section"
-        } else{
-        label.var <- paste0("name_",language)
-        to.filter <- noga::lookup[eval(label.var)]
-        matched.successfully <- sapply(var, function(y) sapply(to.filter, function(x) grepl(y,x)))
-        matched.succesfully.index <- which(rowSums(matched.successfully)==1)
-        lookup.filtered <- noga::lookup[matched.succesfully.index,]
-        if(all(!is.na(lookup.filtered$type))==TRUE){noga.level <- "type"}
-        if(all(!is.na(lookup.filtered$class))==TRUE & any(is.na(lookup.filtered$type))==TRUE){noga.level <- "class"}
-        if(all(!is.na(lookup.filtered$group))==TRUE & any(is.na(lookup.filtered$class))==TRUE){noga.level <- "group"}
-        if(all(!is.na(lookup.filtered$division))==TRUE & any(is.na(lookup.filtered$group))==TRUE){noga.level <- "division"}
+      if (nrow(lookup.filtered) == 0) {
+        # No match in the lookup table
+        warning("Please provide the noga level manually, the automatic detection failed.")
       }
 
+      matches_type <- nrow(lookup.filtered[!is.na(lookup.filtered$type), ])
+      matches_class <- nrow(lookup.filtered[!is.na(lookup.filtered$class) & is.na(lookup.filtered$type), ])
+      matches_group <- nrow(lookup.filtered[!is.na(lookup.filtered$group) & is.na(lookup.filtered$class), ])
+      matches_division <- nrow(lookup.filtered[!is.na(lookup.filtered$division) & is.na(lookup.filtered$group), ])
 
-  }else{
-    noga.level <- switch(as.character(nchar(max(var,na.rm=TRUE))),
-                         "1"="section",
-                         "2"="division",
-                         "3"="group",
-                         "4"="class",
-                         "6"="type",
-                         warning("Please provide the noga level manually, the automatic detection failed."))
+      matches <- c("division" = matches_division, "group" = matches_group,
+                   "class" = matches_class, "type" = matches_type)
+
+      noga.level <- names(which(matches == max(matches)))
+
+      # If ties, take the deepest level
+      if (length(noga.level) > 1) {
+        if ("type" %in% noga.level) {
+          noga.level <- "type"
+        } else if ("class" %in% noga.level) {
+          noga.level <- "class"
+        } else if ("group" %in% noga.level){
+          noga.level <- "group"
+        } else {
+          noga.level <- "division"
+        }
+      }
+    }
+
+  } else {
+    noga.level <- switch(as.character(nchar(max(var, na.rm = TRUE))),
+                         "1" = "section", # This should fail because section codes aren't numeric but sectors can be and aren't supported (yet)
+                         "2" = "division",
+                         "3" = "group",
+                         "4" = "class",
+                         "6" = "type",
+                         warning("Please provide the noga level manually, the automatic detection failed.")
+                        )
   }
+
+  message(paste("Detected level is :", noga.level))
 
   return(noga.level)
 }

--- a/R/directioncheck.R
+++ b/R/directioncheck.R
@@ -2,13 +2,13 @@
 #' @name directioncheck
 #' @noRd
 
-directioncheck <- function(to,vartype,var){
-  if(to=="auto" & vartype%in%c("numeric","integer")){
-    direction.to="labels"
-  }else if(to=="auto" & vartype=="character" & any(grepl("[a-z]",var))){
-    direction.to="values"
-  }else if(to=="auto" & vartype=="character" & (max(nchar(var))==1)|all(grepl("[0-9]",var))){
-    direction.to="labels"
+directioncheck <- function(vartype, var) {
+  if (vartype %in% c("numeric", "integer")) {
+    direction.to <- "labels"
+  } else if (vartype == "character" & any(grepl("[a-zA-Z]", var)) & max(nchar(var)) > 1) {
+    direction.to <- "values"
+  } else if (vartype == "character" & (max(nchar(var)) == 1) | all(grepl("[0-9]", var))) {
+    direction.to <- "labels"
   }
   return(direction.to)
 }

--- a/R/noga_recode.R
+++ b/R/noga_recode.R
@@ -1,20 +1,26 @@
 #' Function to recode a variable containing noga codes to labels and vice versa
 #' @name noga_recode
 #' @param var The variable containing the noga-codes or noga-values that you
-#'  want to recode. Must be numeric or string, factor variables are not supported.
-#'  Note that the function can handle only variables that contain one NOGA-level only.
+#'   want to recode. Must be numeric or string, factor variables are not
+#'   supported. Note that the function can handle only variables that contain
+#'   one NOGA-level only.
 #' @param language One of "de" (German), "en" (English), "fr" (French) or "it"
-#'  (Italian). Defaults to English.
+#'   (Italian). Defaults to English.
 #' @param level The NOGA-Level you want to recode. Must be one of "auto"
-#' (Default), "section" (1. level), "division" (2. level), "group" (3.),
-#' "class" (4.) or "type" (5.). If set to "auto", the NOGA level will be
-#' identified based on the number of digits/characters of the maximum non-missing
-#' value of that variable. The variable you recode can only contain one NOGA-level.
-#' @param to Recode values to labels or vice versa? Defaults to "auto"
-#' (will identify based on the input variable the recoding direction), or
-#' "values" will recode labels to values or "labels" will recode values (codes in string format) to labels.
-#' @param warn TRUE (default) or FALSE. When TRUE will give warnings about non-matching recodings.
-#' @returns a recoded variable in string format (either noga-labels, or noga-codes).
+#'   (Default), "section" (1. level), "division" (2. level), "group" (3.),
+#'   "class" (4.) or "type" (5.). If set to "auto", the NOGA level will be
+#'   identified based on the number of digits/characters of the maximum
+#'   non-missing value of that variable. If all the labels belong to more than
+#'   one level, the deepest one is always used. The variable you recode can only
+#'   contain one NOGA-level.
+#' @param to Recode values to labels or vice versa? Defaults to "auto" (will
+#'   identify based on the input variable the recoding direction), or "values"
+#'   will recode labels to values or "labels" will recode values (codes in
+#'   string format) to labels.
+#' @param warn TRUE (default) or FALSE. When TRUE will give warnings about
+#'   non-matching recodings.
+#' @returns a recoded variable in string format (either noga-labels, or
+#'   noga-codes).
 #' @export
 #' @examples
 #' example.data <- data.frame(

--- a/R/noga_recode.R
+++ b/R/noga_recode.R
@@ -53,7 +53,7 @@ noga_recode <- function(var,language="en",level="auto",to="auto",warn=TRUE){
   if(level!="auto"){
 
     detected.noga.level <- gsub(pattern="(\\.n$)",replacement="",automaticleveldetection(var,language))
-    if(level!=detected.noga.level)warning("The noga level you have supplied manually in the level parameter does not correspond to the automatically detected noga level of the input variable. Expect weird output. If you think the noga level you have supplied does match the one of the varaible and that this is a bug of this function, please open an issue at https://github.com/jbeoh/noga/issues")
+    if(level!=detected.noga.level)warning("The noga level you have supplied manually in the level parameter does not correspond to the automatically detected noga level of the input variable. Expect weird output. If you think the noga level you have supplied does match the one of the variable and that this is a bug of this function, please open an issue at https://github.com/SwissStatsR/noga/issues")
     noga.level <- level
     }else{
     noga.level <- automaticleveldetection(var,language)

--- a/R/noga_recode.R
+++ b/R/noga_recode.R
@@ -42,10 +42,10 @@ noga_recode <- function(var,language="en",level="auto",to="auto",warn=TRUE){
     }
   }
 
-  if(to!="auto"){
+  if (to != "auto") {
     direction.to <- to
-  }else{
-    direction.to <- directioncheck(to,vartype,var)
+  } else {
+    direction.to <- directioncheck(vartype, var)
   }
 
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 [![R-CMD-check](https://github.com/SwissStatsR/noga/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SwissStatsR/noga/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
 
-The noga package provides allows to recode noga values to its labels or
-vice versa. Noga is the European classification system of economic
-activies. The RMD check fails yet because the noga labels are not yet
-supplied in UTF-encoding because to guarantee readibility of the
-characters.
+The noga package allows recoding noga values to their labels or vice
+versa.
+[Noga](https://www.bfs.admin.ch/bfs/en/home/statistics/industry-services/nomenclatures/noga.html)
+is derived from the European classification system of economic
+activities (NACE). NOGA08 is the version currently supported in this
+package.
 
 ## Installation
 
@@ -28,34 +29,51 @@ The package is not yet available on CRAN.
 
 ## NOGA-levels
 
-The Noga clasisfication system has 5 levels which can be recoded with
-this package: - section (alphabetic one character from A to U) -
-division (two digits 01-99) - group (three digits 011-990) - class (four
-digits 0111-9900) - type (six digits 011100-990003)
+The Noga classification system has 5 levels which can be recoded with
+this package:
+
+- section (a single alphabetic character from A to U)
+- division (two digits 01-99)
+- group (three digits 011-990)
+- class (four digits 0111-9900)
+- type (six digits 011100-990003)
 
 Note that if you recode labels to values, the output variable will be in
-string format as the noga-codes are essentially strings rather than a
+string format as the noga codes are essentially strings rather than a
 numeric.
 
 ## Usage
 
-The function `noga::noga_recode` recodes noga values to their labels or
-vice versa. Please note that the vector/variable you recode cannot
-contain multiple noga-levels simultaneously. The function will not be
+The function `noga::noga_recode()` recodes noga values to their labels
+or vice versa. Please note that the vector/variable you recode cannot
+contain multiple noga levels simultaneously. The function will not be
 able to recode a vector that contains both the noga-group and noga-class
-level.
+level. If all given labels are shared across several levels, the deepest
+(most specific) level will be used.
 
 ``` r
 library(noga)
- example.data <- data.frame(
-test1 = c(702,62),
-test2 = c("Management consultancy activities","Extraction of natural gas"),
-test3=c("702","062"))
-noga::noga_recode(var=example.data$test1,language="fr",level="group",to="auto")
+
+example.data <- data.frame(
+  test1 = c(702, 62),
+  test2 = c("Management consultancy activities", "Extraction of natural gas"),
+  test3 = c("702", "062")
+)
+
+noga_recode(var=example.data$test1, language = "fr", level = "group", to = "auto")
+#> Detected level is : group
 #> [1] "Conseil de gestion"        "Extraction de gaz naturel"
-noga::noga_recode(var=example.data$test2,language="en",level="auto",to="values")
+```
+
+``` r
+noga_recode(var=example.data$test2, language = "en", level = "auto", to = "values")
+#> Detected level is : group
 #> [1] "702" "062"
-noga::noga_recode(var=example.data$test3,language="de",level="auto",to="auto")
+```
+
+``` r
+noga_recode(var=example.data$test3, language = "de", level = "auto", to = "auto")
+#> Detected level is : group
 #> [1] "Public-Relations- und Unternehmensberatung"
 #> [2] "Gewinnung von Erdgas"
 ```
@@ -68,3 +86,5 @@ noga::noga_recode(var=example.data$test3,language="de",level="auto",to="auto")
   manufacturing, tertiary: services)
 - Include the Noga-50 level of the Swiss FSO that groups Switzerland’s
   largest divisions so that they represent the 50 economic activities
+- When available, include NOGA 2025 recoding (to/from labels and codes,
+  to/from NOGA08)

--- a/Readme.Rmd
+++ b/Readme.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 [![R-CMD-check](https://github.com/SwissStatsR/noga/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/SwissStatsR/noga/actions/workflows/R-CMD-check.yaml)
   <!-- badges: end -->
 
-The noga package provides allows to recode noga values to its labels or vice versa. Noga is the European classification system of economic activies. The RMD check fails yet because the noga labels are not yet supplied in UTF-encoding because to guarantee readibility of the characters.
+The noga package allows recoding noga values to their labels or vice versa. [Noga](https://www.bfs.admin.ch/bfs/en/home/statistics/industry-services/nomenclatures/noga.html) is derived from the European classification system of economic activities (NACE). NOGA08 is the version currently supported in this package.
 
 ## Installation
 
@@ -34,31 +34,36 @@ The package is not yet available on CRAN.
 
 ## NOGA-levels
 
-The Noga clasisfication system has 5 levels which can be recoded with this package:
-- section (alphabetic one character from A to U)
+The Noga classification system has 5 levels which can be recoded with this package:
+
+- section (a single alphabetic character from A to U)
 - division (two digits 01-99)
 - group (three digits 011-990)
 - class (four digits 0111-9900)
 - type (six digits 011100-990003)
 
-Note that if you recode labels to values, the output variable will be in string format as the noga-codes are essentially strings rather than a numeric.
+Note that if you recode labels to values, the output variable will be in string format as the noga codes are essentially strings rather than a numeric.
 
 ## Usage
 
-The function `noga::noga_recode` recodes noga values to their labels or vice versa. Please note that the vector/variable you recode cannot contain multiple noga-levels simultaneously. The function will not be able to recode a vector that contains both the noga-group and noga-class level.
+The function `noga::noga_recode()` recodes noga values to their labels or vice versa. Please note that the vector/variable you recode cannot contain multiple noga levels simultaneously. The function will not be able to recode a vector that contains both the noga-group and noga-class level. If all given labels are shared across several levels, the deepest (most specific) level will be used.
 
 ```{r example}
 library(noga)
- example.data <- data.frame(
-test1 = c(702,62),
-test2 = c("Management consultancy activities","Extraction of natural gas"),
-test3=c("702","062"))
-noga::noga_recode(var=example.data$test1,language="fr",level="group",to="auto")
-noga::noga_recode(var=example.data$test2,language="en",level="auto",to="values")
-noga::noga_recode(var=example.data$test3,language="de",level="auto",to="auto")
+
+example.data <- data.frame(
+  test1 = c(702, 62),
+  test2 = c("Management consultancy activities", "Extraction of natural gas"),
+  test3 = c("702", "062")
+)
+
+noga_recode(var=example.data$test1, language = "fr", level = "group", to = "auto")
+noga_recode(var=example.data$test2, language = "en", level = "auto", to = "values")
+noga_recode(var=example.data$test3, language = "de", level = "auto", to = "auto")
 ```
 
 ## Planned expansion for the future
 - Aggregation function so that values/codes of one level can be aggregated to another one
 - Include economic sectors (primary: raw material, secondary: manufacturing, tertiary: services)
-- Include the Noga-50 level of the Swiss FSO that groups Switzerland's largest divisions so that they represent the 50 economic activities  
+- Include the Noga-50 level of the Swiss FSO that groups Switzerland's largest divisions so that they represent the 50 economic activities
+- When available, include NOGA 2025 recoding (to/from labels and codes, to/from NOGA08)

--- a/man/noga_recode.Rd
+++ b/man/noga_recode.Rd
@@ -8,8 +8,9 @@ noga_recode(var, language = "en", level = "auto", to = "auto", warn = TRUE)
 }
 \arguments{
 \item{var}{The variable containing the noga-codes or noga-values that you
-want to recode. Must be numeric or string, factor variables are not supported.
-Note that the function can handle only variables that contain one NOGA-level only.}
+want to recode. Must be numeric or string, factor variables are not
+supported. Note that the function can handle only variables that contain
+one NOGA-level only.}
 
 \item{language}{One of "de" (German), "en" (English), "fr" (French) or "it"
 (Italian). Defaults to English.}
@@ -17,17 +18,22 @@ Note that the function can handle only variables that contain one NOGA-level onl
 \item{level}{The NOGA-Level you want to recode. Must be one of "auto"
 (Default), "section" (1. level), "division" (2. level), "group" (3.),
 "class" (4.) or "type" (5.). If set to "auto", the NOGA level will be
-identified based on the number of digits/characters of the maximum non-missing
-value of that variable. The variable you recode can only contain one NOGA-level.}
+identified based on the number of digits/characters of the maximum
+non-missing value of that variable. If all the labels belong to more than
+one level, the deepest one is always used. The variable you recode can only
+contain one NOGA-level.}
 
-\item{to}{Recode values to labels or vice versa? Defaults to "auto"
-(will identify based on the input variable the recoding direction), or
-"values" will recode labels to values or "labels" will recode values (codes in string format) to labels.}
+\item{to}{Recode values to labels or vice versa? Defaults to "auto" (will
+identify based on the input variable the recoding direction), or "values"
+will recode labels to values or "labels" will recode values (codes in
+string format) to labels.}
 
-\item{warn}{TRUE (default) or FALSE. When TRUE will give warnings about non-matching recodings.}
+\item{warn}{TRUE (default) or FALSE. When TRUE will give warnings about
+non-matching recodings.}
 }
 \value{
-a recoded variable in string format (either noga-labels, or noga-codes).
+a recoded variable in string format (either noga-labels, or
+  noga-codes).
 }
 \description{
 Function to recode a variable containing noga codes to labels and vice versa

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(noga)
+
+test_check("noga")

--- a/tests/testthat/test-automaticleveldetection.R
+++ b/tests/testthat/test-automaticleveldetection.R
@@ -1,44 +1,156 @@
-test_that("sections can be detected", {
-  type_labels <- c("A", "B", "C")
-  expect_match(automaticleveldetection(type_labels , "en"), "section")
+test_that("sections can be detected from code", {
+  labels <- c("A", "B", "C")
+  expect_match(automaticleveldetection(labels , "en"), "section")
 })
 
-test_that("sections in lowercase can be detected", {
-  type_labels <- c("a", "b", "c")
-  expect_match(automaticleveldetection(type_labels , "en"), "section")
+test_that("sections in lowercase can be detected from code", {
+  labels <- c("a", "b", "c")
+  expect_match(automaticleveldetection(labels , "en"), "section")
 })
 
-test_that("divisions can be detected", {
-  type_labels <- c("Forestry and logging", "Fishing and aquaculture", "Mining of coal and lignite")
-  expect_match(automaticleveldetection(type_labels , "en"), "division")
+test_that("some divisions can be detected from label", {
+  labels <- c("Forestry and logging", "Fishing and aquaculture", "Mining of coal and lignite")
+  expect_match(automaticleveldetection(labels , "en"), "division")
 })
 
-test_that("groups can be detected", {
-  type_labels <- c("Processing and preserving of meat and production of meat products", "Manufacture of dairy products", "Manufacture of weapons and ammunition")
-  expect_match(automaticleveldetection(type_labels , "en"), "group")
+test_that("some groups can be detected from label", {
+  labels <- c("Processing and preserving of meat and production of meat products", "Manufacture of dairy products", "Manufacture of weapons and ammunition")
+  expect_match(automaticleveldetection(labels , "en"), "group")
 })
 
 test_that("classes with the same names as groups can be detected", {
-  type_labels <- c("Preparation and spinning of textile fibres", "Weaving of textiles", "Sawmilling and planing of wood")
-  expect_match(automaticleveldetection(type_labels , "en"), "class")
+  labels <- c("Preparation and spinning of textile fibres", "Weaving of textiles", "Sawmilling and planing of wood")
+  expect_match(automaticleveldetection(labels , "en"), "class")
 })
 
-test_that("classes can be detected", {
-  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of made-up textile articles, except apparel")
-  expect_match(automaticleveldetection(type_labels , "en"), "class")
+test_that("some classes can be detected from label", {
+  labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of made-up textile articles, except apparel")
+  expect_match(automaticleveldetection(labels , "en"), "class")
 })
 
 test_that("types with the same names as groups can be detected", {
-  type_labels <- c("Mining of hard coal", "Mining of lignite", "Extraction of crude petroleum")
-  expect_match(automaticleveldetection(type_labels , "en"), "type")
+  labels <- c("Mining of hard coal", "Mining of lignite", "Extraction of crude petroleum")
+  expect_match(automaticleveldetection(labels , "en"), "type")
 })
 
 test_that("types with the same names as classes can be detected", {
-  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of cheese")
-  expect_match(automaticleveldetection(type_labels , "en"), "type")
+  labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of cheese")
+  expect_match(automaticleveldetection(labels , "en"), "type")
 })
 
-test_that("types can be detected", {
-  type_labels <- c("Manufacture of fresh dairy products", "Manufacture of cheese", "Other milk processing")
-  expect_match(automaticleveldetection(type_labels , "en"), "type")
+test_that("some types can be detected from label", {
+  labels <- c("Manufacture of fresh dairy products", "Manufacture of cheese", "Other milk processing")
+  expect_match(automaticleveldetection(labels , "en"), "type")
 })
+
+### Per language and level
+
+## EN
+
+test_that("english types can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$type), "name_en"]
+  expect_match(automaticleveldetection(labels , "en"), "type")
+})
+
+test_that("english classes can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$class) & is.na(noga::lookup$type), "name_en"]
+  expect_match(automaticleveldetection(labels , "en"), "class")
+})
+
+test_that("english groups can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$group) & is.na(noga::lookup$class), "name_en"]
+  expect_match(automaticleveldetection(labels , "en"), "group")
+})
+
+test_that("english divisions can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$division) & is.na(noga::lookup$group), "name_en"]
+  expect_match(automaticleveldetection(labels , "en"), "division")
+})
+
+test_that("english sections can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$section) & is.na(noga::lookup$division), "name_en"]
+  expect_match(automaticleveldetection(labels , "en"), "section")
+})
+
+## DE
+
+test_that("german types can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$type), "name_de"]
+  expect_match(automaticleveldetection(labels , "de"), "type")
+})
+
+test_that("german classes can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$class) & is.na(noga::lookup$type), "name_de"]
+  expect_match(automaticleveldetection(labels , "de"), "class")
+})
+
+test_that("german groups can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$group) & is.na(noga::lookup$class), "name_de"]
+  expect_match(automaticleveldetection(labels , "de"), "group")
+})
+
+test_that("german divisions can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$division) & is.na(noga::lookup$group), "name_de"]
+  expect_match(automaticleveldetection(labels , "de"), "division")
+})
+
+test_that("german sections can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$section) & is.na(noga::lookup$division), "name_de"]
+  expect_match(automaticleveldetection(labels , "de"), "section")
+})
+
+## FR
+
+test_that("french types can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$type), "name_fr"]
+  expect_match(automaticleveldetection(labels , "fr"), "type")
+})
+
+test_that("french classes can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$class) & is.na(noga::lookup$type), "name_fr"]
+  expect_match(automaticleveldetection(labels , "fr"), "class")
+})
+
+test_that("french groups can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$group) & is.na(noga::lookup$class), "name_fr"]
+  expect_match(automaticleveldetection(labels , "fr"), "group")
+})
+
+test_that("french divisions can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$division) & is.na(noga::lookup$group), "name_fr"]
+  expect_match(automaticleveldetection(labels , "fr"), "division")
+})
+
+test_that("french sections can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$section) & is.na(noga::lookup$division), "name_fr"]
+  expect_match(automaticleveldetection(labels , "fr"), "section")
+})
+
+## IT
+
+test_that("italian types can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$type), "name_it"]
+  expect_match(automaticleveldetection(labels , "it"), "type")
+})
+
+test_that("italian classes can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$class) & is.na(noga::lookup$type), "name_it"]
+  expect_match(automaticleveldetection(labels , "it"), "class")
+})
+
+test_that("italian groups can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$group) & is.na(noga::lookup$class), "name_it"]
+  expect_match(automaticleveldetection(labels , "it"), "group")
+})
+
+test_that("italian divisions can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$division) & is.na(noga::lookup$group), "name_it"]
+  expect_match(automaticleveldetection(labels , "it"), "division")
+})
+
+test_that("italian sections can be detected from label", {
+  labels <- noga::lookup[!is.na(noga::lookup$section) & is.na(noga::lookup$division), "name_it"]
+  expect_match(automaticleveldetection(labels , "it"), "section")
+})
+
+###

--- a/tests/testthat/test-automaticleveldetection.R
+++ b/tests/testthat/test-automaticleveldetection.R
@@ -19,7 +19,7 @@ test_that("groups can be detected", {
 })
 
 test_that("classes with the same names as groups can be detected", {
-  type_labels <- c("Plant propagation", "Mixed farming", "Hunting, trapping and related service activities")
+  type_labels <- c("Preparation and spinning of textile fibres", "Weaving of textiles", "Sawmilling and planing of wood")
   expect_match(automaticleveldetection(type_labels , "en"), "class")
 })
 

--- a/tests/testthat/test-automaticleveldetection.R
+++ b/tests/testthat/test-automaticleveldetection.R
@@ -24,8 +24,7 @@ test_that("classes with the same names as groups can be detected", {
 })
 
 test_that("classes can be detected", {
-  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "
-Manufacture of made-up textile articles, except apparel")
+  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of made-up textile articles, except apparel")
   expect_match(automaticleveldetection(type_labels , "en"), "class")
 })
 

--- a/tests/testthat/test-automaticleveldetection.R
+++ b/tests/testthat/test-automaticleveldetection.R
@@ -1,0 +1,45 @@
+test_that("sections can be detected", {
+  type_labels <- c("A", "B", "C")
+  expect_match(automaticleveldetection(type_labels , "en"), "section")
+})
+
+test_that("sections in lowercase can be detected", {
+  type_labels <- c("a", "b", "c")
+  expect_match(automaticleveldetection(type_labels , "en"), "section")
+})
+
+test_that("divisions can be detected", {
+  type_labels <- c("Forestry and logging", "Fishing and aquaculture", "Mining of coal and lignite")
+  expect_match(automaticleveldetection(type_labels , "en"), "division")
+})
+
+test_that("groups can be detected", {
+  type_labels <- c("Processing and preserving of meat and production of meat products", "Manufacture of dairy products", "Manufacture of weapons and ammunition")
+  expect_match(automaticleveldetection(type_labels , "en"), "group")
+})
+
+test_that("classes with the same names as groups can be detected", {
+  type_labels <- c("Plant propagation", "Mixed farming", "Hunting, trapping and related service activities")
+  expect_match(automaticleveldetection(type_labels , "en"), "class")
+})
+
+test_that("classes can be detected", {
+  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "
+Manufacture of made-up textile articles, except apparel")
+  expect_match(automaticleveldetection(type_labels , "en"), "class")
+})
+
+test_that("types with the same names as groups can be detected", {
+  type_labels <- c("Mining of hard coal", "Mining of lignite", "Extraction of crude petroleum")
+  expect_match(automaticleveldetection(type_labels , "en"), "type")
+})
+
+test_that("types with the same names as classes can be detected", {
+  type_labels <- c("Growing of other non-perennial crops", "Growing of grapes", "Manufacture of cheese")
+  expect_match(automaticleveldetection(type_labels , "en"), "type")
+})
+
+test_that("types can be detected", {
+  type_labels <- c("Manufacture of fresh dairy products", "Manufacture of cheese", "Other milk processing")
+  expect_match(automaticleveldetection(type_labels , "en"), "type")
+})

--- a/tests/testthat/test-directioncheck.R
+++ b/tests/testthat/test-directioncheck.R
@@ -1,0 +1,24 @@
+test_that("direction to labels with numeric works", {
+  codes <- c(0, 1, 2, 3)
+  expect_equal(directioncheck(class(codes), codes), "labels")
+})
+
+test_that("direction to labels with numbers as text works", {
+  codes <- c("01", "02", "03")
+  expect_equal(directioncheck(class(codes), codes), "labels")
+})
+
+test_that("direction to labels with section codes works", {
+  codes <- c("A", "B", "C")
+  expect_equal(directioncheck(class(codes), codes), "labels")
+})
+
+test_that("direction to values with texts works", {
+  codes <- c("This", "could", "be", "a", "label")
+  expect_equal(directioncheck(class(codes), codes), "values")
+})
+
+test_that("direction to values with full caps texts works", {
+  codes <- c("THIS", "COULD", "BE", "A", "SECTION", "LABEL")
+  expect_equal(directioncheck(class(codes), codes), "values")
+})

--- a/tests/testthat/test-noga_recode.R
+++ b/tests/testthat/test-noga_recode.R
@@ -1,0 +1,230 @@
+test_that("auto recoding single digit numeric code to labels works", {
+
+  skip("Auto recoding single digit numeric code is not implemented yet")
+
+  codes <- c(1, 2, 3)
+
+  num_to_labs <- function(language) noga_recode(
+    codes,
+    language,
+    level = "auto",
+    to = "auto"
+  )
+
+  labs_en <- c("Crop and animal production, hunting and related service activities",
+               "Forestry and logging",
+               "Fishing and aquaculture")
+  labs_de <- c("Landwirtschaft, Jagd und damit verbundene Tätigkeiten",
+               "Forstwirtschaft und Holzeinschlag",
+               "Fischerei und Aquakultur")
+  labs_fr <- c("Culture et production animale, chasse et services annexes",
+               "Sylviculture et exploitation forestière",
+               "Pêche et aquaculture")
+  labs_it <- c("Produzioni vegetali e animali, caccia e servizi connessi",
+               "Silvicoltura e utilizzo di aree forestali",
+               "Pesca e acquicoltura")
+
+  expect_equal(num_to_labs("en"), labs_en)
+  expect_equal(num_to_labs("de"), labs_de)
+  expect_equal(num_to_labs("fr"), labs_fr)
+  expect_equal(num_to_labs("it"), labs_it)
+})
+
+test_that("auto recoding numeric code to labels works", {
+
+  num_to_labs <- function(codes, language) noga_recode(
+    codes,
+    language,
+    level = "auto",
+    to = "auto"
+  )
+
+  ### Division
+  cd_div <- c(10, 20, 30)
+
+  labs_div_en <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_en"]
+  labs_div_de <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_de"]
+  labs_div_fr <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_fr"]
+  labs_div_it <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_it"]
+
+
+  expect_equal(num_to_labs(cd_div, "en"), labs_div_en)
+  expect_equal(num_to_labs(cd_div, "de"), labs_div_de)
+  expect_equal(num_to_labs(cd_div, "fr"), labs_div_fr)
+  expect_equal(num_to_labs(cd_div, "it"), labs_div_it)
+
+  ### Group
+  cd_grp <- c(201, 431, 512)
+
+  labs_grp_en <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_en"]
+  labs_grp_de <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_de"]
+  labs_grp_fr <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_fr"]
+  labs_grp_it <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_it"]
+
+
+  expect_equal(num_to_labs(cd_grp, "en"), labs_grp_en)
+  expect_equal(num_to_labs(cd_grp, "de"), labs_grp_de)
+  expect_equal(num_to_labs(cd_grp, "fr"), labs_grp_fr)
+  expect_equal(num_to_labs(cd_grp, "it"), labs_grp_it)
+
+  ### Class
+  cd_cls <- c(1512, 3240, 5122)
+
+  labs_cls_en <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_en"]
+  labs_cls_de <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_de"]
+  labs_cls_fr <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_fr"]
+  labs_cls_it <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_it"]
+
+
+  expect_equal(num_to_labs(cd_cls, "en"), labs_cls_en)
+  expect_equal(num_to_labs(cd_cls, "de"), labs_cls_de)
+  expect_equal(num_to_labs(cd_cls, "fr"), labs_cls_fr)
+  expect_equal(num_to_labs(cd_cls, "it"), labs_cls_it)
+
+  ### Type
+  cd_type <- c(192000, 309100, 464202)
+
+  labs_type_en <- lookup[(lookup$type %in% cd_type), "name_en"]
+  labs_type_de <- lookup[(lookup$type %in% cd_type), "name_de"]
+  labs_type_fr <- lookup[(lookup$type %in% cd_type), "name_fr"]
+  labs_type_it <- lookup[(lookup$type %in% cd_type), "name_it"]
+
+
+  expect_equal(num_to_labs(cd_type, "en"), labs_type_en)
+  expect_equal(num_to_labs(cd_type, "de"), labs_type_de)
+  expect_equal(num_to_labs(cd_type, "fr"), labs_type_fr)
+  expect_equal(num_to_labs(cd_type, "it"), labs_type_it)
+})
+
+test_that("auto recoding numeric code as strings to labels works", {
+
+  strg_code_to_labs <- function(codes, language) noga_recode(
+    codes,
+    language,
+    level = "auto",
+    to = "auto"
+  )
+
+  ### Division
+  cd_div <- c("01", "20", "46")
+
+  labs_div_en <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_en"]
+  labs_div_de <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_de"]
+  labs_div_fr <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_fr"]
+  labs_div_it <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_it"]
+
+
+  expect_equal(strg_code_to_labs(cd_div, "en"), labs_div_en)
+  expect_equal(strg_code_to_labs(cd_div, "de"), labs_div_de)
+  expect_equal(strg_code_to_labs(cd_div, "fr"), labs_div_fr)
+  expect_equal(strg_code_to_labs(cd_div, "it"), labs_div_it)
+
+  ### Group
+  cd_grp <- c("011", "110", "512")
+
+  labs_grp_en <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_en"]
+  labs_grp_de <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_de"]
+  labs_grp_fr <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_fr"]
+  labs_grp_it <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_it"]
+
+
+  expect_equal(strg_code_to_labs(cd_grp, "en"), labs_grp_en)
+  expect_equal(strg_code_to_labs(cd_grp, "de"), labs_grp_de)
+  expect_equal(strg_code_to_labs(cd_grp, "fr"), labs_grp_fr)
+  expect_equal(strg_code_to_labs(cd_grp, "it"), labs_grp_it)
+
+  ### Class
+  cd_cls <- c("0112", "1310", "5122")
+
+  labs_cls_en <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_en"]
+  labs_cls_de <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_de"]
+  labs_cls_fr <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_fr"]
+  labs_cls_it <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_it"]
+
+
+  expect_equal(strg_code_to_labs(cd_cls, "en"), labs_cls_en)
+  expect_equal(strg_code_to_labs(cd_cls, "de"), labs_cls_de)
+  expect_equal(strg_code_to_labs(cd_cls, "fr"), labs_cls_fr)
+  expect_equal(strg_code_to_labs(cd_cls, "it"), labs_cls_it)
+
+  ### Type
+  cd_type <- c("011100", "309100", "464202")
+
+  labs_type_en <- lookup[(lookup$type %in% cd_type), "name_en"]
+  labs_type_de <- lookup[(lookup$type %in% cd_type), "name_de"]
+  labs_type_fr <- lookup[(lookup$type %in% cd_type), "name_fr"]
+  labs_type_it <- lookup[(lookup$type %in% cd_type), "name_it"]
+
+
+  expect_equal(strg_code_to_labs(cd_type, "en"), labs_type_en)
+  expect_equal(strg_code_to_labs(cd_type, "de"), labs_type_de)
+  expect_equal(strg_code_to_labs(cd_type, "fr"), labs_type_fr)
+  expect_equal(strg_code_to_labs(cd_type, "it"), labs_type_it)
+})
+
+test_that("auto recoding labels to codes works", {
+
+  labs_to_codes <- function(labels, language) noga_recode(
+    labels,
+    language,
+    level = "auto",
+    to = "auto"
+  )
+
+  ### Division
+  cd_div <- c("01", "20", "46")
+
+  labs_div_en <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_en"]
+  labs_div_de <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_de"]
+  labs_div_fr <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_fr"]
+  labs_div_it <- lookup[(lookup$division %in% cd_div & is.na(lookup$group)), "name_it"]
+
+
+  expect_equal(labs_to_codes(labs_div_en, "en"), cd_div)
+  expect_equal(labs_to_codes(labs_div_de, "de"), cd_div)
+  expect_equal(labs_to_codes(labs_div_fr, "fr"), cd_div)
+  expect_equal(labs_to_codes(labs_div_it, "it"), cd_div)
+
+  ### Group
+  cd_grp <- c("011", "110", "512")
+
+  labs_grp_en <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_en"]
+  labs_grp_de <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_de"]
+  labs_grp_fr <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_fr"]
+  labs_grp_it <- lookup[(lookup$group %in% cd_grp & is.na(lookup$class)), "name_it"]
+
+
+  expect_equal(labs_to_codes(labs_grp_en, "en"), cd_grp)
+  expect_equal(labs_to_codes(labs_grp_de, "de"), cd_grp)
+  expect_equal(labs_to_codes(labs_grp_fr, "fr"), cd_grp)
+  expect_equal(labs_to_codes(labs_grp_it, "it"), cd_grp)
+
+  ### Class
+  # Only classes without shared names with types
+  cd_cls <- c("1051", "1082", "1413")
+
+  labs_cls_en <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_en"]
+  labs_cls_de <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_de"]
+  labs_cls_fr <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_fr"]
+  labs_cls_it <- lookup[(lookup$class %in% cd_cls & is.na(lookup$type)), "name_it"]
+
+
+  expect_equal(labs_to_codes(labs_cls_en, "en"), cd_cls)
+  expect_equal(labs_to_codes(labs_cls_de, "de"), cd_cls)
+  expect_equal(labs_to_codes(labs_cls_fr, "fr"), cd_cls)
+  expect_equal(labs_to_codes(labs_cls_it, "it"), cd_cls)
+
+  ### Type
+  cd_type <- c("011100", "309100", "464202")
+
+  labs_type_en <- lookup[(lookup$type %in% cd_type), "name_en"]
+  labs_type_de <- lookup[(lookup$type %in% cd_type), "name_de"]
+  labs_type_fr <- lookup[(lookup$type %in% cd_type), "name_fr"]
+  labs_type_it <- lookup[(lookup$type %in% cd_type), "name_it"]
+
+
+  expect_equal(labs_to_codes(labs_type_en, "en"), cd_type)
+  expect_equal(labs_to_codes(labs_type_de, "de"), cd_type)
+  expect_equal(labs_to_codes(labs_type_fr, "fr"), cd_type)
+  expect_equal(labs_to_codes(labs_type_it, "it"), cd_type)
+})


### PR DESCRIPTION
Autodetect uses exact matching (lab %in% all_labels) to avoid cases where partial matches can detect elements which are at the beginning of a label (eg. Enseignement (division level) is also found in Enseignement primaire (class level) or Enseignement de la conduite (class and type levels)) or have the same end (eg. Aquakultur (group level) is also found in "Fischerei und Aquakultur" (division level)).

Autodetect returns the deepest level if there are ties in the number of matches per level. It also issues a message to inform which levels were found and which one was "detected".

There are several tests added to make sure the autodetection and the recoding is working for some simple cases. They may be extended to check for more complex cases.

The possible NOGA 2025 expansion has been added to the README and some typos were fixed.

fixes #19, fixes #20, and fixes #21. 